### PR TITLE
Shelf preview options

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -33,11 +33,10 @@ Icons are simply png files (keep them reasonably sized, they only show up around
 
 ### Shelf Size
 
-The shelf size is determined in one of three ways in order of priority:
+The shelf size is determined in one of two ways in order of priority:
 
 1. ShelfBounds json value - this is an XYZ Vector3.  Specifically X determines the width of the shelf space needed, and Y determines the height needed.  Z is not currently used.
 1. ShelfPrefab box collider size
-1. Item Prefab box collider size
 
 If the size cannot be determined in one of those ways, a default shelf space of .2 x .2 meters will be assumed.
 

--- a/README.MD
+++ b/README.MD
@@ -59,3 +59,4 @@ If the size cannot be determined in one of those ways, a default shelf space of 
 - ShelfBounds - Vector3: This is the width, height, and depth (x, y, z) of the item on the shelf
 - ShelfScale - Vector3: A scaling factor to apply to the item placed on the shelf (either the shelf prefab or the item prefab) to help it fit.  Scaling is per vector.
 - ShelfRotation - Vector3: Rotation in Eurler angles to apply to the shelf item.  If provided, this will override the automatic rotation applied to item prefab if no shelf prefab is provided.
+- PreviewRotation - Vector3: This rotation is applied to the item when placing it in the world using the "place" command (R by default on keyboard)

--- a/README.MD
+++ b/README.MD
@@ -38,7 +38,7 @@ The shelf size is determined in one of two ways in order of priority:
 1. ShelfBounds json value - this is an XYZ Vector3.  Specifically X determines the width of the shelf space needed, and Y determines the height needed.  Z is not currently used.
 1. ShelfPrefab box collider size
 
-If the size cannot be determined in one of those ways, a default shelf space of .2 x .2 meters will be assumed.
+If the size cannot be determined in one of those ways, a default shelf space of .35 x .3 meters will be assumed.
 
 ### JSON Fields
 

--- a/README.MD
+++ b/README.MD
@@ -36,7 +36,7 @@ Icons are simply png files (keep them reasonably sized, they only show up around
 The shelf size is determined in one of two ways in order of priority:
 
 1. ShelfBounds json value - this is an XYZ Vector3.  Specifically X determines the width of the shelf space needed, and Y determines the height needed.  Z is not currently used.
-1. ShelfPrefab box collider size
+1. ShelfPrefab box collider size (only used if a shelf prefab is provided)
 
 If the size cannot be determined in one of those ways, a default shelf space of .35 x .3 meters will be assumed.
 
@@ -56,6 +56,6 @@ If the size cannot be determined in one of those ways, a default shelf space of 
 **Optional Fields:**
 - ShelfPrefabPath - string: This is the path within the asset bundle to get to your shelf prefab if provided.  If missing, the item prefab will be used rotated 180 degrees.
 - ShelfBounds - Vector3: This is the width, height, and depth (x, y, z) of the item on the shelf
-- ShelfScale - Vector3: A scaling factor to apply to the item placed on the shelf (either the shelf prefab or the item prefab) to help it fit.  Scaling is per vector.
-- ShelfRotation - Vector3: Rotation in Eurler angles to apply to the shelf item.  If provided, this will override the automatic rotation applied to item prefab if no shelf prefab is provided.
+- ShelfScale - Vector3: A scaling factor to apply to the item placed on the shelf (either the shelf prefab or the item prefab) to help it fit.  Scaling is non-uniform (unless x,y,and z match), and a full vector3 is required.
+- ShelfRotation - Vector3: Rotation in Euler angles (Roll Pitch Yaw) in degrees to apply to the shelf item.  If provided, this will override the automatic rotation applied to item prefab if no shelf prefab is provided.
 - PreviewRotation - Vector3: This rotation is applied to the item when placing it in the world using the "place" command (R by default on keyboard)

--- a/README.MD
+++ b/README.MD
@@ -13,3 +13,49 @@ This mod doesn't do anything by itself! You have to create a custom item [like t
 ## How to create your own custom item
 
 Follow the instructions [here](https://git.tostiman.com/tostiman/dv_blahaj).
+
+## Item guide
+
+This section is all about best practices for making an item.  The tips in this section will help you get to a working item in the minimum time.
+
+### Item Prefab
+
+When building your prefab, it's important to establish the prefab's origin at the bottom front of your model.  This is usually done by offsetting the model as a child of the prefab, though can be done by ensuring that the exported model has it's origin at the bottom front.
+The prefab should be set up so that it's front is along the **-Z** axis and the top along the **+Y** axis.  The prefab should include a box collider or mesh collider to enable interaction.  Box collider is preferred unless it's excessively sized relative to the actual mesh.
+
+### Shelf Prefab
+
+The shelf prefab is an optional prefab.  If provided, this is what will be placed on the shelf.  It can include multiple copies of your item, or a creative arrangement.  It should be oriented with the front along the **+Z** axis and the top along the **+Y** axis. It should have a single box collider that wraps the entire visible portion of the prefab.
+
+### Icons
+
+Icons are simply png files (keep them reasonably sized, they only show up around 300x300 pixels, maybe a bit bigger on 4k screens...).  In Unity they must be marked as sprites (after importing the png, select it and in the properties window on the right change from texture to sprite).
+
+### Shelf Size
+
+The shelf size is determined in one of three ways in order of priority:
+
+1. ShelfBounds json value - this is an XYZ Vector3.  Specifically X determines the width of the shelf space needed, and Y determines the height needed.  Z is not currently used.
+1. ShelfPrefab box collider size
+1. Item Prefab box collider size
+
+If the size cannot be determined in one of those ways, a default shelf space of .2 x .2 meters will be assumed.
+
+### JSON Fields
+
+**Required Fields:**
+
+- Name - string : This is the name that will be displayed in game
+- Description - string: This will be displayed when hovering over the item to purchase it.
+- Amount - integer: This is the number of items available to purchase
+- Price - integer: This is how much the item will cost in career mode (affected by career settings) 
+- AssetBundleName - string: This is the filename of the built asset bundle
+- PrefabPath - string: This is the path within the asset bundle to get to your item prefab (this should be listed in your asset bundle manifest and end in .prefab)
+- IconStandardPath - string: This is the path within the asset bundle to the icon asset for inventory view.
+- IconDroppedPath - string: This is the path within the asset bundle to the icon asset for locked slots in inventory where the item is missing. 
+
+**Optional Fields:**
+- ShelfPrefabPath - string: This is the path within the asset bundle to get to your shelf prefab if provided.  If missing, the item prefab will be used rotated 180 degrees.
+- ShelfBounds - Vector3: This is the width, height, and depth (x, y, z) of the item on the shelf
+- ShelfScale - Vector3: A scaling factor to apply to the item placed on the shelf (either the shelf prefab or the item prefab) to help it fit.  Scaling is per vector.
+- ShelfRotation - Vector3: Rotation in Eurler angles to apply to the shelf item.  If provided, this will override the automatic rotation applied to item prefab if no shelf prefab is provided.

--- a/src/CustomItem.cs
+++ b/src/CustomItem.cs
@@ -63,7 +63,7 @@ public class CustomItem
 		var previewBounds = new Vector3(0.35f, 0.3f, 0.2f);
 		if (previewRotation == default) { previewRotation = Vector3.zero; }
 
-		var itemSpec = SetupItemSpec(ItemPrefab, Name, immuneToDumpster, isEssential, iconStandard, iconDropped, previewBounds, itemInfo.previewRotation);
+		var itemSpec = SetupItemSpec(ItemPrefab, Name, immuneToDumpster, isEssential, iconStandard, iconDropped, previewBounds, itemInfo.PreviewRotation);
 		Main.Log($"Built item spec for {itemInfo.Name}");
 
 		var shelfObject = new GameObject();

--- a/src/CustomItem.cs
+++ b/src/CustomItem.cs
@@ -23,14 +23,16 @@ public class CustomItem
 	public InventoryItemSpec ItemSpec => ShopData.item;
 	public ShopItemData ShopData { get; private set; }
 
-	public GameObject ProvidedPrefab { get; private set; }
-	private CustomItemInfo itemInfo;
+	private readonly GameObject providedItemPrefab;
+	private readonly GameObject providedShelfPrefab;
+	private readonly CustomItemInfo itemInfo;
 	
 	
 	/// <param name="itemInfo">The parsed item info json</param>
-	/// <param name="unityPrefab">the prefab of the item as extracted from the asset bundle</param>
+	/// <param name="providedItemPrefab">the prefab of the item as extracted from the asset bundle</param>
 	/// <param name="iconStandard">the inventory icon</param>
 	/// <param name="iconDropped">this icon will be shown in your inventory when you've dropped the item. For vanilla game items, this is a blue (#72A2B3) silhouette of the item.</param>
+	/// <param name="providedShelfPrefab">This prefab, if it exists, will be used for the shelf item.  This can have multiple items, different orientations, etc</param>
 	/// <param name="previewRotation">TODO what is this</param>
 	/// <param name="soldOnlyAt">item will only be available at these shops</param>
 	/// <param name="previewBounds">TODO IDK what this is</param>
@@ -39,10 +41,11 @@ public class CustomItem
 	/// <param name="isEssential">if true, the item will leave a ghost in your inventory when you drop it and the inventory slot will be reserved for this item</param>
 	public CustomItem(
 		CustomItemInfo itemInfo,
-		GameObject unityPrefab,
+		GameObject providedItemPrefab,
 		Sprite iconStandard,
 		Sprite iconDropped,
-		Vector3 previewRotation = default,
+        GameObject providedShelfPrefab = default,
+        Vector3 previewRotation = default,
 		List<Shop> soldOnlyAt = default,
 		bool careerOnly = false,
 		bool immuneToDumpster = true,
@@ -58,13 +61,13 @@ public class CustomItem
 		
 		Name = itemInfo.Name;
 		Description = itemInfo.Description;
-		ItemPrefab = CreateItemPrefab(unityPrefab);
-		ProvidedPrefab = unityPrefab;
+		ItemPrefab = CreateItemPrefab(providedItemPrefab);
+		this.providedItemPrefab = providedItemPrefab;
 
 		Main.Log($"Loaded prefabs for {itemInfo.Name}");
 
 		Vector3 previewBounds = default;
-		var collider = ProvidedPrefab.GetComponentInChildren<BoxCollider>();
+		var collider = this.providedItemPrefab.GetComponentInChildren<BoxCollider>();
 		if (collider != null)
 		{
 			previewBounds = collider.size;
@@ -117,8 +120,8 @@ public class CustomItem
 		tag.name = "ScanItem";
 
 		// Add a preview object to show on the shelf
-		var shopSample = UnityEngine.Object.Instantiate(ProvidedPrefab);
-		shopSample.name = $"{ProvidedPrefab.name} - preview";
+		var shopSample = UnityEngine.Object.Instantiate(providedItemPrefab);
+		shopSample.name = $"{providedItemPrefab.name} - preview";
 		shopSample.transform.parent = ShopData.shelfItem.transform;
 		// this probably needs to be adjusted for other items - we may want to make this something in the json?
 		// TODO: figure out a sane way to calculate this.

--- a/src/CustomItem.cs
+++ b/src/CustomItem.cs
@@ -40,8 +40,8 @@ public class CustomItem
 		GameObject providedItemPrefab,
 		Sprite iconStandard,
 		Sprite iconDropped,
-        GameObject providedShelfPrefab = default,
-        Vector3 previewRotation = default,
+		GameObject providedShelfPrefab = default,
+		Vector3 previewRotation = default,
 		List<Shop> soldOnlyAt = default,
 		bool careerOnly = false,
 		bool immuneToDumpster = true,
@@ -112,11 +112,11 @@ public class CustomItem
 		};
 	}
 
-    /// <summary>
-    /// Called to handle initialization steps that depend on GlobalShopController
-    /// </summary>
-    /// <param name="shopController"></param>
-    public void FinishInitialization(GlobalShopController shopController)
+	/// <summary>
+	/// Called to handle initialization steps that depend on GlobalShopController
+	/// </summary>
+	/// <param name="shopController"></param>
+	public void FinishInitialization(GlobalShopController shopController)
 	{
 		// Create the scan tag for purchasing
 		var tag = Object.Instantiate(shopController.scanItemShelfPrefab.transform.Find("ScanItem"));
@@ -234,32 +234,32 @@ public class CustomItem
 		return itemSpec;
 	}
 
-    private static void AddShelfSample(GameObject shelfObject, CustomItemInfo itemInfo, GameObject providedItemPrefab, GameObject providedShelfPrefab = default)
-    {
-        // Add a preview object to show on the shelf
-        GameObject shopSample;
-        if (providedShelfPrefab != default)
-        {
-            shopSample = UnityEngine.Object.Instantiate(providedShelfPrefab);
-            shopSample.name = providedShelfPrefab.name;
-        }
-        else
-        {
-            shopSample = UnityEngine.Object.Instantiate(providedItemPrefab);
-            shopSample.name = $"{providedItemPrefab.name} - preview";
-        }
-        shopSample.transform.parent = shelfObject.transform;
-        if (itemInfo.ShelfRotation != default)
-        {
-            shopSample.transform.eulerAngles = itemInfo.ShelfRotation;
-        }
-        else if (providedShelfPrefab == default)
-        {
-            shopSample.transform.eulerAngles = new Vector3(0, 180, 0);
-        }
-        if (itemInfo.ShelfScale != default)
-        {
-            shopSample.transform.localScale = itemInfo.ShelfScale;
-        }
-    }
+	private static void AddShelfSample(GameObject shelfObject, CustomItemInfo itemInfo, GameObject providedItemPrefab, GameObject providedShelfPrefab = default)
+	{
+		// Add a preview object to show on the shelf
+		GameObject shopSample;
+		if (providedShelfPrefab != default)
+		{
+			shopSample = UnityEngine.Object.Instantiate(providedShelfPrefab);
+			shopSample.name = providedShelfPrefab.name;
+		}
+		else
+		{
+			shopSample = UnityEngine.Object.Instantiate(providedItemPrefab);
+			shopSample.name = $"{providedItemPrefab.name} - preview";
+		}
+		shopSample.transform.parent = shelfObject.transform;
+		if (itemInfo.ShelfRotation != default)
+		{
+			shopSample.transform.eulerAngles = itemInfo.ShelfRotation;
+		}
+		else if (providedShelfPrefab == default)
+		{
+			shopSample.transform.eulerAngles = new Vector3(0, 180, 0);
+		}
+		if (itemInfo.ShelfScale != default)
+		{
+			shopSample.transform.localScale = itemInfo.ShelfScale;
+		}
+	}
 }

--- a/src/CustomItem.cs
+++ b/src/CustomItem.cs
@@ -29,7 +29,6 @@ public class CustomItem
 	/// <param name="iconStandard">the inventory icon</param>
 	/// <param name="iconDropped">this icon will be shown in your inventory when you've dropped the item. For vanilla game items, this is a blue (#72A2B3) silhouette of the item.</param>
 	/// <param name="providedShelfPrefab">This prefab, if it exists, will be used for the shelf item.  This can have multiple items, different orientations, etc</param>
-	/// <param name="previewRotation">TODO what is this</param>
 	/// <param name="soldOnlyAt">item will only be available at these shops</param>
 	/// <param name="previewBounds">TODO IDK what this is</param>
 	/// <param name="careerOnly">if true, the item can only be purchased it career mode</param>
@@ -41,7 +40,6 @@ public class CustomItem
 		Sprite iconStandard,
 		Sprite iconDropped,
 		GameObject providedShelfPrefab = default,
-		Vector3 previewRotation = default,
 		List<Shop> soldOnlyAt = default,
 		bool careerOnly = false,
 		bool immuneToDumpster = true,
@@ -74,7 +72,7 @@ public class CustomItem
 		}
 		if (previewRotation == default) { previewRotation = Vector3.zero; }
 
-		var itemSpec = SetupItemSpec(ItemPrefab, Name, immuneToDumpster, isEssential, iconStandard, iconDropped, previewBounds, previewRotation);
+		var itemSpec = SetupItemSpec(ItemPrefab, Name, immuneToDumpster, isEssential, iconStandard, iconDropped, previewBounds, itemInfo.previewRotation);
 		Main.Log($"Built item spec for {itemInfo.Name}");
 
 		var shelfObject = new GameObject();

--- a/src/CustomItem.cs
+++ b/src/CustomItem.cs
@@ -49,19 +49,14 @@ public class CustomItem
 		// C# pls
 		if (soldOnlyAt == default(List<Shop>)) { soldOnlyAt = new List<Shop>(); }
 		Main.Log($"Instantiating {itemInfo.Name}");
-
-		// save item info for later use
-		//this.itemInfo = itemInfo;
 		
 		Name = itemInfo.Name;
 		Description = itemInfo.Description;
 		ItemPrefab = CreateItemPrefab(providedItemPrefab);
-		//this.providedItemPrefab = providedItemPrefab;
 
 		Main.Log($"Loaded prefabs for {itemInfo.Name}");
 
 		var previewBounds = new Vector3(0.35f, 0.3f, 0.2f);
-		if (previewRotation == default) { previewRotation = Vector3.zero; }
 
 		var itemSpec = SetupItemSpec(ItemPrefab, Name, immuneToDumpster, isEssential, iconStandard, iconDropped, previewBounds, itemInfo.PreviewRotation);
 		Main.Log($"Built item spec for {itemInfo.Name}");

--- a/src/CustomItem.cs
+++ b/src/CustomItem.cs
@@ -74,7 +74,7 @@ public class CustomItem
 		}
 		if (previewRotation == default) { previewRotation = Vector3.zero; }
 
-		var itemSpec = SetupItemSpec(providedItemPrefab, Name, immuneToDumpster, isEssential, iconStandard, iconDropped, previewBounds, previewRotation);
+		var itemSpec = SetupItemSpec(ItemPrefab, Name, immuneToDumpster, isEssential, iconStandard, iconDropped, previewBounds, previewRotation);
 		Main.Log($"Built item spec for {itemInfo.Name}");
 
 		var shelfObject = new GameObject();

--- a/src/CustomItem.cs
+++ b/src/CustomItem.cs
@@ -24,6 +24,7 @@ public class CustomItem
 	public ShopItemData ShopData { get; private set; }
 
 	public GameObject ProvidedPrefab { get; private set; }
+	private CustomItemInfo itemInfo;
 	
 	
 	/// <param name="itemInfo">The parsed item info json</param>
@@ -51,6 +52,9 @@ public class CustomItem
 		// C# pls
 		if (soldOnlyAt == default(List<Shop>)) { soldOnlyAt = new List<Shop>(); }
 		Main.Log($"Instantiating {itemInfo.Name}");
+
+		// save item info for later use
+		this.itemInfo = itemInfo;
 		
 		Name = itemInfo.Name;
 		Description = itemInfo.Description;
@@ -59,19 +63,15 @@ public class CustomItem
 
 		Main.Log($"Loaded prefabs for {itemInfo.Name}");
 
-		var previewBounds = itemInfo.PreviewBounds;
-		Main.Log($"Preview bounds: {previewBounds}");
-		if (previewBounds == default)
+		Vector3 previewBounds = default;
+		var collider = ProvidedPrefab.GetComponentInChildren<BoxCollider>();
+		if (collider != null)
 		{
-			var collider = ProvidedPrefab.GetComponentInChildren<BoxCollider>();
-			if (collider != null)
-			{
-				previewBounds = collider.size;
-			}
-			else
-			{
-				previewBounds = new Vector3(0.2f, 0.2f, 0.2f);
-			}
+			previewBounds = collider.size;
+		}
+		else
+		{
+			previewBounds = new Vector3(0.2f, 0.2f, 0.2f);
 		}
 		if (previewRotation == default) { previewRotation = Vector3.zero; }
 
@@ -83,7 +83,14 @@ public class CustomItem
 		shelfObject.transform.parent = ItemPrefab.transform.parent;
 		shelfObject.name = $"{ItemPrefab.name}_ShelfItem";
 		var shelfItemComponent = shelfObject.AddComponent<ShelfItem>();
-		shelfItemComponent.size = new Vector2(previewBounds.x, previewBounds.y);
+
+		// shelf bounds may be defined in the json, or it may be defined by a collider on the main object, or it may be defaulted
+		var shelfSize = itemInfo.ShelfBounds;
+		if (shelfSize == default)
+		{
+			shelfSize = previewBounds;
+		}
+		shelfItemComponent.size = new Vector2(shelfSize.x, shelfSize.y);
 
 		Main.Log($"Built shelf object for {itemInfo.Name}");
 		

--- a/src/CustomItem.cs
+++ b/src/CustomItem.cs
@@ -89,9 +89,16 @@ public class CustomItem
 
 		// shelf bounds may be defined in the json, or it may be defined by a collider on the main object, or it may be defaulted
 		var shelfSize = itemInfo.ShelfBounds;
-		if (shelfSize == default)
+		if (shelfSize == default && providedShelfPrefab == default)
 		{
 			shelfSize = previewBounds;
+		} else if (shelfSize == default && providedShelfPrefab != default) {
+			var shelfCollider = providedShelfPrefab.GetComponent<BoxCollider>();
+			if (shelfCollider != null)
+			{
+				shelfSize = shelfCollider.size;
+			}
+			else shelfSize = previewBounds;
 		}
 		shelfItemComponent.size = new Vector2(shelfSize.x, shelfSize.y);
 
@@ -120,12 +127,26 @@ public class CustomItem
 		tag.name = "ScanItem";
 
 		// Add a preview object to show on the shelf
-		var shopSample = UnityEngine.Object.Instantiate(providedItemPrefab);
-		shopSample.name = $"{providedItemPrefab.name} - preview";
+		GameObject shopSample;
+		if (providedShelfPrefab != default)
+		{
+			shopSample = UnityEngine.Object.Instantiate(providedShelfPrefab);
+			shopSample.name = providedShelfPrefab.name;
+		}
+		else
+		{
+			shopSample = UnityEngine.Object.Instantiate(providedItemPrefab);
+			shopSample.name = $"{providedItemPrefab.name} - preview";
+		}
 		shopSample.transform.parent = ShopData.shelfItem.transform;
-		// this probably needs to be adjusted for other items - we may want to make this something in the json?
-		// TODO: figure out a sane way to calculate this.
-		shopSample.transform.localPosition = new Vector3(0f, 0f, -0.1f);
+		if (itemInfo.ShelfRotation != default)
+		{
+			shopSample.transform.eulerAngles = itemInfo.ShelfRotation;
+		}
+		if (itemInfo.ShelfScale != default)
+		{
+			shopSample.transform.localScale = itemInfo.ShelfScale;
+		}
 
 		// Add the ScanItemCashRegisterModule to the shelf item
 		var module = ShopData.shelfItem.gameObject.AddComponent<ScanItemCashRegisterModule>();

--- a/src/CustomItemInfo.cs
+++ b/src/CustomItemInfo.cs
@@ -6,17 +6,24 @@ namespace custom_item_mod;
 [Serializable]
 public class CustomItemInfo
 {
+	// Required info fields
 	public string Name;
 	public string Description;
 	public int Amount;
 	public int Price;
 	
+	// Required asset references
 	public string AssetBundleName;
 	public string PrefabPath;
-	public string ShelfPrefabPath;
 	public string IconStandardPath;
 	public string IconDroppedPath;
-	public Vector3 ShelfBounds;
+
+	// Optional Asset References
+    public string ShelfPrefabPath;
+
+	//Optional info fields
+    public Vector3 ShelfBounds;
 	public Vector3 ShelfScale;
 	public Vector3 ShelfRotation;
+	public Vector3 PreviewRotation;
 }

--- a/src/CustomItemInfo.cs
+++ b/src/CustomItemInfo.cs
@@ -19,10 +19,10 @@ public class CustomItemInfo
 	public string IconDroppedPath;
 
 	// Optional Asset References
-    public string ShelfPrefabPath;
+	public string ShelfPrefabPath;
 
 	//Optional info fields
-    public Vector3 ShelfBounds;
+	public Vector3 ShelfBounds;
 	public Vector3 ShelfScale;
 	public Vector3 ShelfRotation;
 	public Vector3 PreviewRotation;

--- a/src/CustomItemInfo.cs
+++ b/src/CustomItemInfo.cs
@@ -13,7 +13,10 @@ public class CustomItemInfo
 	
 	public string AssetBundleName;
 	public string PrefabPath;
+	public string ShelfPrefabPath;
 	public string IconStandardPath;
 	public string IconDroppedPath;
-	public Vector3 PreviewBounds;
+	public Vector3 ShelfBounds;
+	public Vector3 ShelfScale;
+	public Vector3 ShelfRotation;
 }

--- a/src/ItemModsFinder.cs
+++ b/src/ItemModsFinder.cs
@@ -105,8 +105,17 @@ public static class ItemModsFinder
 		var prefab = assBundle.LoadAsset<GameObject>(itemInfo.PrefabPath);
 		if (prefab == null)
 		{
-			Main.Error($"Failed to load {nameof(prefab)} from item {itemInfo.Name} at {itemInfo.PrefabPath}");
+			Main.Error($"Failed to load Item Prefab from item {itemInfo.Name} at {itemInfo.PrefabPath}");
 			success = false;
+		}
+		GameObject shelfPrefab = default;
+		if (itemInfo.ShelfPrefabPath != default)
+		{
+			shelfPrefab = assBundle.LoadAsset<GameObject>(itemInfo.ShelfPrefabPath);
+			if (shelfPrefab == null)
+			{
+				Main.Error($"Failed to load Shelf Prefab from item {itemInfo.Name} at {itemInfo.ShelfPrefabPath}");
+			}
 		}
 		
 		var iconStandard = assBundle.LoadAsset<Sprite>(itemInfo.IconStandardPath);

--- a/src/ItemModsFinder.cs
+++ b/src/ItemModsFinder.cs
@@ -187,7 +187,6 @@ public static class ItemModsFinder
 				item.AddToShop(shop);
 			}
 		}
-		instance.initialAmounts.Clear();
 		instance.InitializeShopData();
 		instance.SetupListeners(true);
 	}

--- a/src/ItemModsFinder.cs
+++ b/src/ItemModsFinder.cs
@@ -138,7 +138,8 @@ public static class ItemModsFinder
 				itemInfo,
 				prefab,
 				iconStandard,
-				iconDropped
+				iconDropped,
+				shelfPrefab
 				//todo implement more parameters?
 			);
 			return item;


### PR DESCRIPTION
This merge request completes the rest of the new capabilities related to Build 99, specifically the ability to have a different preview item on the shelf.

Further advancement and refinement is, of course, possible, but this should satisfy 99% of item makers at this time and provides a solid foundation for gadgets.

Further, the readme includes documentation on best practices to create fully working items.

This should come after #8 

Also, combined with #7 and #8, this fully resolves #1 and #5.